### PR TITLE
rpc: add semaphore to input_stream reading

### DIFF
--- a/src/rpc/rpc_connection.h
+++ b/src/rpc/rpc_connection.h
@@ -15,6 +15,7 @@ class rpc_connection {
   input_stream<char> istream;
   output_stream<char> ostream;
 
+  uint32_t istream_active_parser{0};
 
   void disable() { enabled_ = false; }
   bool is_enabled() const { return enabled_; }

--- a/src/rpc/rpc_recv_context.cc
+++ b/src/rpc/rpc_recv_context.cc
@@ -39,11 +39,69 @@ uint32_t rpc_recv_context::request_id() const { return payload->meta(); }
 uint32_t rpc_recv_context::status() const { return payload->meta(); }
 
 
+future<temporary_buffer<char>> read_payload(rpc_connection *conn,
+                                            rpc_connection_limits *limits,
+                                            size_t payload_size) {
+  if(limits == nullptr) {
+    return conn->istream.read_exactly(payload_size);
+  } else {
+    return limits->wait_for_payload_resources(payload_size)
+      .then([payload_size, conn]() {
+        return conn->istream.read_exactly(payload_size);
+      });
+  }
+}
+
+future<optional<rpc_recv_context>>
+process_payload(rpc_connection *conn,
+                rpc_connection_limits *limits,
+                temporary_buffer<char> header) {
+  using ret_type = optional<rpc_recv_context>;
+  auto hdr = reinterpret_cast<const fbs::rpc::Header *>(header.get());
+  return read_payload(conn, limits, hdr->size())
+    .then([header_buf =
+             std::move(header)](temporary_buffer<char> body) mutable {
+      using namespace fbs::rpc;
+      auto hdr = reinterpret_cast<const Header *>(header_buf.get());
+
+      if(hdr->size() != body.size()) {
+        LOG_ERROR("Read incorrect number of bytes `{}`, expected header: `{}`",
+                  body.size(), *hdr);
+        return make_ready_future<ret_type>(nullopt);
+      }
+
+      /// HAS TO BE FIRST. This is the last thing that happens on the
+      /// sender
+      /// side. So if the content is compressed, it happens BEFORE it's
+      /// crc
+      /// checked
+      if((hdr->flags() & Flags::Flags_CHECKSUM) == Flags::Flags_CHECKSUM) {
+        const uint32_t xx = xxhash(body.get(), body.size());
+        if(xx != hdr->checksum()) {
+          LOG_ERROR("Payload checksum `{}` does not match header checksum `{}`",
+                    xx, hdr->checksum());
+          return make_ready_future<ret_type>(nullopt);
+        }
+      }
+
+      if((hdr->flags() & Flags::Flags_SNAPPY) == Flags::Flags_SNAPPY) {
+        LOG_ERROR("Snappy compression not supported yet");
+      }
+
+      return make_ready_future<ret_type>(
+        rpc_recv_context(std::move(header_buf), std::move(body)));
+    });
+}
+
 future<optional<rpc_recv_context>>
 rpc_recv_context::parse(rpc_connection *conn, rpc_connection_limits *limits) {
   using ret_type = optional<rpc_recv_context>;
   static constexpr size_t kRPCHeaderSize = sizeof(fbs::rpc::Header);
 
+  /// serializes access to the input_stream
+  /// without this line you can have interleaved reads on the buffer
+  assert(conn->istream_active_parser == 0);
+  conn->istream_active_parser++;
   return conn->istream.read_exactly(kRPCHeaderSize)
     .then([conn, limits](temporary_buffer<char> header) {
       if(kRPCHeaderSize != header.size()) {
@@ -59,53 +117,9 @@ rpc_recv_context::parse(rpc_connection *conn, rpc_connection_limits *limits) {
         LOG_ERROR("Emty body to parse. skipping");
         return make_ready_future<ret_type>(nullopt);
       }
-
-      auto limits_fn = [limits, conn](size_t payload_size) {
-        if(limits == nullptr) {
-          return conn->istream.read_exactly(payload_size);
-        } else {
-          return limits->wait_for_payload_resources(payload_size)
-            .then([payload_size, conn]() {
-              return conn->istream.read_exactly(payload_size);
-            });
-        }
-      };
-
-      return limits_fn(hdr->size())
-        .then([header_buf =
-                 std::move(header)](temporary_buffer<char> body) mutable {
-          using namespace fbs::rpc;
-          auto hdr = reinterpret_cast<const Header *>(header_buf.get());
-
-          if(hdr->size() != body.size()) {
-            LOG_ERROR(
-              "Read incorrect number of bytes `{}`, expected header: `{}`",
-              body.size(), *hdr);
-            return make_ready_future<ret_type>(nullopt);
-          }
-
-          /// HAS TO BE FIRST. This is the last thing that happens on the sender
-          /// side. So if the content is compressed, it happens BEFORE it's crc
-          /// checked
-          if((hdr->flags() & Flags::Flags_CHECKSUM) == Flags::Flags_CHECKSUM) {
-            const uint32_t xx = xxhash(body.get(), body.size());
-            if(xx != hdr->checksum()) {
-              LOG_ERROR(
-                "Payload checksum `{}` does not match header checksum `{}`", xx,
-                hdr->checksum());
-              return make_ready_future<ret_type>(nullopt);
-            }
-          }
-
-          if((hdr->flags() & Flags::Flags_SNAPPY) == Flags::Flags_SNAPPY) {
-            LOG_ERROR("Snappy compression not supported yet");
-          }
-
-          return make_ready_future<ret_type>(
-            rpc_recv_context(std::move(header_buf), std::move(body)));
-        });
-
-    });
+      return process_payload(conn, limits, std::move(header));
+    })
+    .finally([conn] { conn->istream_active_parser--; });
 }
 
 } // end namespace


### PR DESCRIPTION
* if you dispatch parallel futures to read from
the same input_stream<char>::read_exactly() then
you get incorrect results as the server might send
multiple bytes through. Since our protocol does 2
reads, we need to ensure that these 2 reads happen
in atomically and only 2 of them happen at the same
time.