### PR TITLE
rpc: add move_filter_apply algorithm for filters

### DIFF
--- a/src/rpc/rpc_incoming_filter.h
+++ b/src/rpc/rpc_incoming_filter.h
@@ -1,9 +1,7 @@
 #pragma once
-#include <experimental/optional>
 #include "rpc/rpc_recv_context.h"
 namespace smf {
 struct rpc_incoming_filter {
-  virtual future<std::experimental::optional<rpc_recv_context>>
-  apply(rpc_recv_context ctx) = 0;
+  virtual future<rpc_recv_context> apply(rpc_recv_context &&ctx) = 0;
 };
 }

--- a/src/rpc/rpc_server.h
+++ b/src/rpc/rpc_server.h
@@ -52,6 +52,9 @@ class rpc_server {
   future<> dispatch_rpc(lw_shared_ptr<rpc_server_connection> conn,
                         rpc_recv_context &&ctx);
 
+  future<rpc_recv_context> apply_incoming_filters(rpc_recv_context &&ctx);
+  future<rpc_envelope> apply_outgoing_filters(rpc_envelope &&e);
+
   private:
   lw_shared_ptr<server_socket> listener_;
   distributed<rpc_server_stats> &stats_;


### PR DESCRIPTION
The rpc mechanism was missing the ability to accept
arbitrary chains of incoming filters and outgoing filters.

The algorithm is generalized by the `move_filter_apply` function

It takes a pair of iterators (begin, end) and a value and moves them
around.  In fact there is an opportunity to specialize them